### PR TITLE
Make it possible to specify multiple Workspaces to keep

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trampoline/workplate",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Use Yarn Workspaces to define complex project templates.",
   "bin": "dist/index.js",
   "repository": "https://github.com/Trampoline-CX/workplate.git",

--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -11,7 +11,7 @@ export interface CreateArgs {
 }
 
 export interface CreateOptions {
-  workspace?: string
+  workspace?: string[]
 }
 
 export const create = (args: CreateArgs, options: CreateOptions, logger: CaporalLogger): void => {

--- a/src/commands/create/keep-relevant-files.ts
+++ b/src/commands/create/keep-relevant-files.ts
@@ -14,14 +14,14 @@ export const keepRelevantFiles = (
   rmdirSync(path.join(repoPath, '.git'), { recursive: true })
 
   // Keep only certain templates, if --template option is provided
-  if (typeof options.workspace === 'string' && options.workspace.length > 0) {
+  if (options.workspace && options.workspace.length > 0) {
     _keepRelevantWorkspaces(repoPath, options.workspace, logger)
   }
 }
 
 const _keepRelevantWorkspaces = (
   repoPath: string,
-  workspaceName: string,
+  workspaceNames: string[],
   logger: CaporalLogger,
 ): void => {
   logger.debug('Getting list of workspaces in repo.')
@@ -33,7 +33,9 @@ const _keepRelevantWorkspaces = (
   const parsedInfo: WorkspacesInfo = JSON.parse(workspacesInfo)
   const workspacesToKeep: WorkspacesInfo = {}
 
-  _recursiveGetDependencies(parsedInfo, workspaceName, workspacesToKeep)
+  for (const name of workspaceNames) {
+    _recursiveGetDependencies(parsedInfo, name, workspacesToKeep)
+  }
   logger.debug('Workspaces to keep', workspacesInfo)
 
   const workspacesToRemove = Object.fromEntries(

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ prog
     },
   )
   .argument('<repository>', 'Repository URL to clone from')
-  .option('-w, --workspace <template>', 'Workspace Name to clone', prog.STRING)
+  .option('-w, --workspace <template>', 'Workspace Name to clone', prog.REPEATABLE)
   .action((args, options, logger) => {
     create(args as CreateArgs, options as CreateOptions, logger)
   })

--- a/src/package-info.json
+++ b/src/package-info.json
@@ -1,1 +1,1 @@
-{ "version": "0.0.2", "description": "Use Yarn Workspaces to define complex project templates." }
+{ "version": "0.0.3", "description": "Use Yarn Workspaces to define complex project templates." }


### PR DESCRIPTION
We can now specify the `--workspace` parameter multiple times to keep multiple unrelated workspaces.